### PR TITLE
Fix links to the next training

### DIFF
--- a/_layouts/katacoda-fs.html
+++ b/_layouts/katacoda-fs.html
@@ -23,7 +23,7 @@
             </div>
             <div id="center">
                 <li>
-                    <a href="#top">🔝&nbsp;Lab</a>&nbsp;&nbsp;{% if page.walkthrough %}<a href="#walkthrough-screencast">📺&nbsp;Walk&nbsp;me&nbsp;through</a>&nbsp;&nbsp;{% endif %}{% if page.more %}<a href="#more">⭐&nbsp;More</a>{% endif %}</li></div>
+                    <a href="{{ site.url }}/modules/tag/online-devops-dojo/">🔝&nbsp;Lab</a>&nbsp;&nbsp;{% if page.walkthrough %}<a href="#walkthrough-screencast">📺&nbsp;Walk&nbsp;me&nbsp;through</a>&nbsp;&nbsp;{% endif %}{% if page.more %}<a href="#more">⭐&nbsp;More</a>{% endif %}</li></div>
             <div id="right">
                 <li>
                     <a href="https://github.com/dxc-technology/online-devops-dojo/issues/new?template=need_assistance.md&title=Need+assistance+with+module+{{ page.katacoda_scenario }}" target="_blank" style="target-new: tab;">🙋‍ Get help</a> 

--- a/_posts/modules/2019-07-22-os1-welcome.md
+++ b/_posts/modules/2019-07-22-os1-welcome.md
@@ -19,13 +19,9 @@ katacoda_next_scenario: os2-leading-change
 <div id="katacoda-scenario-1"
     data-katacoda-id="{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_scenario }}"
     data-katacoda-ctatext="Continue Online DevOps Dojo"
-    data-katacoda-ctaurl="https://www.katacoda.com/{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_next_scenario }}"
+    data-katacoda-ctaurl="{{ site.url }}/katacoda/{{ page.katacoda_next_scenario }}"
     data-katacoda-color="004d7f"
+    data-katacoda-font="GT-Walsheim-Pro-Regular"
+    data-katacoda-fontheader="GT-Walsheim-Pro-Bold"
     style="height: calc(100vh); width: (100% - 68px); padding-top: 55px;"></div>
 <br>
-
-<!--
-# Walkthrough screencast
-
-<iframe width="100%" height="90%" src="https://web.microsoftstream.com/embed/video/7f0a71ff-c589-421f-a647-77fa90edaae8?autoplay=false&showinfo=false" frameborder="0" allowfullscreen ></iframe>
--->

--- a/_posts/modules/2019-07-22-os2-leading-change.md
+++ b/_posts/modules/2019-07-22-os2-leading-change.md
@@ -18,6 +18,6 @@ katacoda_next_scenario: os3-version_control
 <div id="katacoda-scenario-1"
     data-katacoda-id="{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_scenario }}"
     data-katacoda-ctatext="Continue Online DevOps Dojo"
-    data-katacoda-ctaurl="https://www.katacoda.com/{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_next_scenario }}"
+    data-katacoda-ctaurl="{{ site.url }}/katacoda/{{ page.katacoda_next_scenario }}"
     data-katacoda-color="004d7f"
     style="height: calc(100vh); width: (100% - 68px); padding-top: 55px;"></div>

--- a/_posts/modules/2019-07-22-os3-version-control.md
+++ b/_posts/modules/2019-07-22-os3-version-control.md
@@ -20,7 +20,7 @@ katacoda_next_scenario: os4-continuous-integration
 <div id="katacoda-scenario-1"
     data-katacoda-id="{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_scenario }}"
     data-katacoda-ctatext="Continue Online DevOps Dojo"
-    data-katacoda-ctaurl="https://www.katacoda.com/{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_next_scenario }}"
+    data-katacoda-ctaurl="{{ site.url }}/katacoda/{{ page.katacoda_next_scenario }}"
     data-katacoda-color="004d7f"
     style="height: calc(100vh); width: (100% - 68px); padding-top: 55px;"></div>
 <br>

--- a/_posts/modules/2019-07-22-os4-continuous-integration.md
+++ b/_posts/modules/2019-07-22-os4-continuous-integration.md
@@ -18,7 +18,7 @@ katacoda_next_scenario: os5-shift-left-security
 <div id="katacoda-scenario-1"
     data-katacoda-id="{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_scenario }}"
     data-katacoda-ctatext="Continue Online DevOps Dojo"
-    data-katacoda-ctaurl="https://www.katacoda.com/{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_next_scenario }}"
+    data-katacoda-ctaurl="{{ site.url }}/katacoda/{{ page.katacoda_next_scenario }}"
     data-katacoda-color="004d7f"
     style="height: calc(100vh); width: (100% - 68px); padding-top: 55px;"></div>
 <br>

--- a/_posts/modules/2019-07-22-os5-shift-left-security.md
+++ b/_posts/modules/2019-07-22-os5-shift-left-security.md
@@ -18,7 +18,7 @@ katacoda_next_scenario: os1-welcome
 <div id="katacoda-scenario-1"
     data-katacoda-id="{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_scenario }}"
     data-katacoda-ctatext="Continue Online DevOps Dojo"
-    data-katacoda-ctaurl="https://www.katacoda.com/{{ page.katacoda_account }}/courses/{{ page.katacoda_course }}/{{ page.katacoda_next_scenario }}"
+    data-katacoda-ctaurl="{{ site.url }}/katacoda/{{ page.katacoda_next_scenario }}"
     data-katacoda-color="004d7f"
     style="height: calc(100vh); width: (100% - 68px); padding-top: 55px;"></div>
 <br>


### PR DESCRIPTION
and fix link "Top" in the banner.
The data-katacoda-font is a try.

I assume that we don't want student to get https://www.katacoda.com/online-devops-dojo/courses/online-devops-dojo
and it is better to get instead a page like:
- https://dxc-technology.github.io/about-devops-dojo/modules/tag/online-devops-dojo/
- than with the large banner with the ninja https://dxc-technology.github.io/about-devops-dojo/modules/